### PR TITLE
Installation fix

### DIFF
--- a/mwp/Makefile
+++ b/mwp/Makefile
@@ -25,6 +25,8 @@ endif
 
 OPTS+= --vapidir $(COMMOND) -X -I$(COMMOND) --pkg mwpfuncs
 
+BASH_COMPLETION_DIR := $(shell pkg-config --variable=completionsdir bash-completion | sed 's/^\/usr\///')
+
 all: $(APPS)
 
 COMMOND=../common
@@ -74,6 +76,5 @@ install: $(APPS)
 	glib-compile-schemas $(datadir)/share/glib-2.0/schemas
 	install -d $(datadir)/share/doc/mwp
 	install -m 644 ../docs/mwptools.pdf $(datadir)/share/doc/mwp/mwptools.pdf
-	install -d /etc/bash_completion.d/
-	install -m 644 mwp_complete.sh /etc/bash_completion.d/mwp
-	gtk-update-icon-cache $(datadir)/share/icons/hicolor
+	install -d $(datadir)/$(BASH_COMPLETION_DIR)
+	install -m 644 mwp_complete.sh $(datadir)/$(BASH_COMPLETION_DIR)/mwp

--- a/samples/area-tool/Makefile
+++ b/samples/area-tool/Makefile
@@ -44,7 +44,7 @@ install: $(APPS)
 	install -d $(prefix)/bin
 	install -s $(APP) $(prefix)/bin/$(APP)
 	install -d $(datadir)/share/mwp
+	install -d $(datadir)/share/applications
 	install -m 644 mwp-area-planner.desktop $(datadir)/share/applications/mwp-area-planner.desktop
 	install -d $(datadir)/share/icons/hicolor/scalable/apps
 	install -m 644 mwp_area_icon.svg $(datadir)/share/icons/hicolor/scalable/apps/mwp_area_icon.svg
-	gtk-update-icon-cache $(datadir)/share/icons/hicolor


### PR DESCRIPTION
The installation of the AUR package was failing for me, and the following fixed it:

+ Removal of the call to `gtk-update-icon-cache`: it errored out saying that the specified theme was not valid.
  + _The new package's icons are fine after installation even with this command removed, though._
+ The directory of bash completion files is now being pulled from `pkg-config`, as [suggested in the FAQs](https://github.com/scop/bash-completion/blob/master/README.md#faq).
  + _Note: my system had them under `/usr`, the implementation in this PR **will not** handle systems where they are directly under `/etc`._

I'm not entirely sure that these modifications are the way to go - this is my first time editing a Makefile manually - so please feel free to point me in the right direction.