### PR TITLE
Recognize verbose signed commits in version script

### DIFF
--- a/mwp/mkvers.sh
+++ b/mwp/mkvers.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 dstr=$(date +%F)
-txt=$(git log -1 --format="%h" 2>/dev/null || echo "local")
+txt=$(git rev-parse --short HEAD 2>/dev/null || echo "local")
 txt="$txt / $dstr"
 if [ -f .master ] ; then
  y=$(($(date +%y)-17))


### PR DESCRIPTION
Using git's plumbing commands should avoid issues with verbose log configurations, thus fixing #41.