### PR TITLE
fix version query for 'nav_rth_home_offset_distance'

### DIFF
--- a/src/mwp/mwp.vala
+++ b/src/mwp/mwp.vala
@@ -6946,7 +6946,7 @@ case 0:
                     queue_cmd(MSP.Cmds.COMMON_SETTING, s, s.length+1);
                     s="gps_min_sats";
                     queue_cmd(MSP.Cmds.COMMON_SETTING, s, s.length+1);
-                    if(vi.fc_vers >= FCVERS.hasPOI) // also 2.6 feature
+                    if(vi.fc_vers > FCVERS.hasJUMP && vi.fc_vers <= FCVERS.hasPOI) // also 2.6 feature
                     {
                         s="nav_rth_home_offset_distance";
                         queue_cmd(MSP.Cmds.COMMON_SETTING, s, s.length+1);


### PR DESCRIPTION
Only inav versions > 2.5.0 and <= 2.6.0 have this setting
(if I read the git log correctly).

Signed-off-by: Stefan Naewe <stefan.naewe@gmail.com>