### PR TITLE
additional mapping file tag to use game controller buttons as switches

### DIFF
--- a/docs/manual/docs/mwp-hid-device-support.md
+++ b/docs/manual/docs/mwp-hid-device-support.md
@@ -4,7 +4,7 @@
 
 From 25.05.07, {{ mwp }} supports using a HID (Human Input Device) to provide RC (stick / switch inputs) to the FC.  An example of this might be running mwp on a game console such as SteamDeck and using the SteamDeck HID (sticks, buttons) to provide TX functions.
 
-While mwp provides functionality for doing this, it is not condoned as an acceptable way of controlling a UAS. Using `NSP_SET_RAW_RC` (aka `MSPRC`) over a MSP telemetry link cannot provide the update rate / performance / reliability / safety of a standard RC TX/RX.
+While mwp provides functionality for doing this, it is not condoned as an acceptable way of controlling a UAS. Using `MSP_SET_RAW_RC` (aka `MSPRC`) over a MSP telemetry link cannot provide the update rate / performance / reliability / safety of a standard RC TX/RX.
 
 ## Prerequisites
 
@@ -84,7 +84,7 @@ Definition lines are of the form `Axis N = Channel X` or `Button M = Channel Y`.
 
 * The `Axis N` or `Button M` data is that shown by `mwp-hid-test`. The Channel is the RC channel for that input.
 * mwp maps the value from SDL (-32608 to 32607) to RC range 1000-2000. Buttons are mapped from off = 1000 to on = 2000.
-* It is possible to set an input as inverted or define a deadband.
+* It is possible to set an input as inverted, make buttons toggleable with "latch", or define a deadband.
 
 Currently the mapping is fixed; if necessary this could be expanded to allow the user to further define the mapping (change ranges, etc.), if that is found necessary.
 For Game Controllers, it is (probably) possible to provide a SDL Mapping file as a parameter to mwp-hid-test (for example, see https://github.com/mdqinc/SDL_GameControllerDB), that will (possibly) help the SDL library to manage the device.
@@ -102,16 +102,16 @@ Axis 1 = Channel 3 invert ; Throttle
 Axis 0 = Channel 4 ; Rudder
 
 # Switches
-Button 9 = Channel 5 ; SE (Arming) (L1)
+Button 9 = Channel 5 latch ; SE (Arming) (L1)
 Axis 4 = Channel 6 ; SA (L2)
-Button 10 = Channel 7 ; SB (R1)
+Button 10 = Channel 7 latch ; SB (R1)
 Axis 5 = Channel 8 ; SC (R2)
 
 # More switches
-Button 12 = Channel 9 ; SD (R3)
-Button 13 = Channel 10 ; SF (L3)
-Button 14 = Channel 11 ; SG (R4)
-Button 15 = Channel 12 ; SH (L4)
+Button 12 = Channel 9 latch ; SD (R3)
+Button 13 = Channel 10 latch ; SF (L3)
+Button 14 = Channel 11 latch ; SG (R4)
+Button 15 = Channel 12 latch ; SH (L4)
 
 # Buttons
 Button 0 = Channel 13 ; SI (A)
@@ -124,7 +124,7 @@ Button 3 = Channel 16 ; SL (Y)
 # Maybe use for local configurations and triggers
 ```
 
-Note the use of `invert`. Mapping file courtesy of GH user @arealmess.
+Note the use of `invert` and `latch`. Mapping file courtesy of GH user @arealmess.
 
 
 ### mwp-hid-test usage

--- a/src/samples/hidex/hid-reader.vala
+++ b/src/samples/hidex/hid-reader.vala
@@ -3,6 +3,7 @@ public class JoyReader {
 		int channel;
 		int last;
 		bool invert;
+		bool? latch;
 	}
 
 	public ChanDef []axes;
@@ -52,6 +53,12 @@ public class JoyReader {
 	public void set_button(int na, bool val) {
 		var chn = buttons[na].channel;
 		int cval;
+		if (buttons[na].latch != null) {  
+			if (val) { 
+				buttons[na].latch = (buttons[na].latch == true) ? false : true;
+			} 
+			val = buttons[na].latch ?? false;
+		} 
 		if (buttons[na].invert) {
 			cval = (val) ? 1000 : 2000;
 		} else {
@@ -85,6 +92,7 @@ public class JoyReader {
 					MatchInfo mi;
 					uint nf;
 					int nc = 0;
+					bool? latch = null;
 					if(rx.match(line, 0, out mi)) {
 						nf = uint.parse(mi.fetch(2));
 						nc = int.parse(mi.fetch(3));
@@ -98,9 +106,13 @@ public class JoyReader {
 										invert = true;
 										break;
 									}
+									if (p == "latch") {
+										latch = false;
+										break;
+									}
 								}
 							}
-							ChanDef chdef = {nc, 0, invert};
+							ChanDef chdef = {nc, 0, invert, latch};
 
 							switch(mi.fetch(1)) {
 							case "Axis":

--- a/src/samples/hidex/hid-reader.vala
+++ b/src/samples/hidex/hid-reader.vala
@@ -92,13 +92,13 @@ public class JoyReader {
 					MatchInfo mi;
 					uint nf;
 					int nc = 0;
-					bool? latch = null;
 					if(rx.match(line, 0, out mi)) {
 						nf = uint.parse(mi.fetch(2));
 						nc = int.parse(mi.fetch(3));
 						if(nc > 0 && nc < 17) {
 							var extra = mi.fetch(4);
 							bool invert = false;
+							bool? latch = null;
 							if(extra != null) {
 								var parts = extra.split(" ");
 								foreach(var p in parts) {


### PR DESCRIPTION
init_latched_buttons is called on joy device added. it parses the mapping file for button lines ending in an asterisk, and adds it to a hashtable with the button # as the key and the ButtonState struct of bools as the value.

edge_latch is called on button presses if present in the hashtable. it looks up the state struct and uses "locked" to prevent cycling while pressed, and unlocks when released. each button press flips the "toggle" bool in its state.

i think this is a convenient place to have this feature, and almost all game controllers will need this kind of functionality, as they have no positional switches.

https://github.com/user-attachments/assets/dc8e2760-b5ad-4de6-b0e1-5516bf11f9c7
