### PR TITLE
update install script 

### DIFF
--- a/docs/deb-install.sh
+++ b/docs/deb-install.sh
@@ -54,7 +54,7 @@ sudo apt update && sudo apt full-upgrade && \
     libprotobuf-c-dev \
     libxml2-utils \
     librsvg2-dev \
-    libsdl2-compat-dev libreadline-dev \
+    libsdl2-dev libreadline-dev \
     gnuplot ruby-nokogiri unzip
 
 [ -n "$DEPSONLY" ] && exit
@@ -63,7 +63,7 @@ git clone --depth 1 https://github.com/stronnag/mwptools
 (
   mkdir -p ~/.local/bin
   cd mwptools
-  git checkout mwp4
+  git checkout master
   meson setup _build --buildtype=release --strip --prefix ~/.local
   ninja -C _build install
 )

--- a/docs/deb-install.sh
+++ b/docs/deb-install.sh
@@ -54,8 +54,12 @@ sudo apt update && sudo apt full-upgrade && \
     libprotobuf-c-dev \
     libxml2-utils \
     librsvg2-dev \
-    libsdl2-dev libreadline-dev \
+    libreadline-dev \
     gnuplot ruby-nokogiri unzip
+  # For Sid/Trixie/Aaarch
+  sudo apt $CONFIRM install libsdl2-compat-dev 
+  # For Bookworm/Ubuntu 24.04+
+  sudo apt $CONFIRM install libsdl2-dev 
 
 [ -n "$DEPSONLY" ] && exit
 
@@ -63,7 +67,8 @@ git clone --depth 1 https://github.com/stronnag/mwptools
 (
   mkdir -p ~/.local/bin
   cd mwptools
-  git checkout master
+  # Change to `git checkout legacy` to install on Debian Bookworm
+  git checkout master 
   meson setup _build --buildtype=release --strip --prefix ~/.local
   ninja -C _build install
 )


### PR DESCRIPTION
Update deb-install.sh
libsdl2-compat-dev not available anymore, needs to use libsdl2-dev now or libsdl3-dev. 
See https://ubuntu.pkgs.org/25.04/ubuntu-universe-arm64/libsdl2-compat-dev_2.32.50+ds-1_arm64.deb.html

gtk4 branch > master